### PR TITLE
chore: release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+## [1.0.0](https://github.com/florian-sanders/zed-stylelint/compare/0.0.4...1.0.0) (2025-07-05)
+
+
+### ✨ Features
+
+* Get `vscode-stylelint` from `open-vsx` ([f69b19c](https://github.com/florian-sanders/zed-stylelint/f69b19c5eda5c5d31ed0a9e774295ecc98cb3d64)) - Fixes [#13](https://github.com/florian-sanders/zed-stylelint/issues/13) 
+  * This removes the need for a fork of the `vscode-stylelint` extension
+
+### 📚 Documentation
+
+* **README:** Remove the "limitations" section ([ddf9b30](https://github.com/florian-sanders/zed-stylelint/ddf9b300308f1ae36ca3d27af5a617ca90bca12c))
+  * Issues mentioned in the limitations section have been resolved so it is
+no longer relevant
+
+
+## [0.0.4](https://github.com/florian-sanders/zed-stylelint/compare/0.0.3...0.0.4) (2025-03-30)
+
+
+### 🐛 Bug Fixes
+
+* **extension.toml:** Add `vue.js` to supported languages ([adbaaaf](https://github.com/florian-sanders/zed-stylelint/adbaaaf60ffee4a72540dc37a6887f0d64a6ab89)) - Fixes [#9](https://github.com/florian-sanders/zed-stylelint/issues/9) 
+
+### 📚 Documentation
+
+* **README:** Add section about vue.js support ([ad15780](https://github.com/florian-sanders/zed-stylelint/ad15780f9b0f1bb47673d9c089cc0eceaac45962)) - Fixes [#9](https://github.com/florian-sanders/zed-stylelint/issues/9) 
+
+
+## [0.0.3](https://github.com/florian-sanders/zed-stylelint/compare/0.0.2...0.0.3) (2025-03-10)
+
+
+### 🐛 Bug Fixes
+
+* **extension.toml:** Add `less` to supported languages ([69ec199](https://github.com/florian-sanders/zed-stylelint/69ec1999494f1c4aa718d9b11192af4f3c71903c)) - Fixes [#4](https://github.com/florian-sanders/zed-stylelint/issues/4) 
+
+### 📚 Documentation
+
+* **README:** Add missing `stylelint` section in settings ([31960f3](https://github.com/florian-sanders/zed-stylelint/31960f310d5907d817a410ce5e9cc5fd2e5240d6)) - Fixes [#6](https://github.com/florian-sanders/zed-stylelint/issues/6) 
+
+
+## [0.0.1](https://github.com/florian-sanders/zed-stylelint/compare/...0.0.1) (2025-02-28)
+
+
+### ♻️ Refactoring
+
+* Change npm package name ([346583a](https://github.com/florian-sanders/zed-stylelint/346583ac6748fff0aad902b4732a472670ef96a8))
+
+### ✨ Features
+
+* Init 0.1.0 ([8c18108](https://github.com/florian-sanders/zed-stylelint/8c181086f883d0397016d086e9bb7ca6cfc69910))
+
+### 🐛 Bug Fixes
+
+* Adapt to github repo renaming ([187c44d](https://github.com/florian-sanders/zed-stylelint/187c44d5e55ecb15d1927af9feaa8081cc2999b3))
+
+* Switch to npm package instead of github release ([e0bf9f5](https://github.com/florian-sanders/zed-stylelint/e0bf9f5f436b0519bd3d2300078e5cec55f7f664)) - Fixes [#2](https://github.com/florian-sanders/zed-stylelint/issues/2) 
+
+* **dependencies:** Upgrade `zed_extension_api` to `0.2.0` ([ba88a12](https://github.com/florian-sanders/zed-stylelint/ba88a12e7b0f64a610eeba7f2b2db2f0dd087f13))
+
+* **languages:** Add scss ([6d7ad84](https://github.com/florian-sanders/zed-stylelint/6d7ad845a34662093547bdd81cfeaffea99e658c))
+
+### 📚 Documentation
+
+* **README:** Update for release ([b285281](https://github.com/florian-sanders/zed-stylelint/b285281df9dbce1163b06099eb592319d13005dc))
+
+* **description:** Add proper description ([a4790f7](https://github.com/florian-sanders/zed-stylelint/a4790f7e5d4cdbfb121d99caf2d797a51efc6655))
+
+* **README:** Fix `fixall` on save example ([4e6935f](https://github.com/florian-sanders/zed-stylelint/4e6935f65b729051d1b2b783fff0ae39e222a56e))
+
+* **README:** Remove `how to install` section ([b84cfc1](https://github.com/florian-sanders/zed-stylelint/b84cfc15a377e985fb422bcf3e5af63b795c4f16))
+  * The extension has been released to this section is obsolete
+
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "zed-stylelint"
-version = "0.0.4"
+version = "1.0.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed-stylelint"
-version = "0.0.4"
+version = "1.0.0"
 edition = "2024"
 
 [lib]

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "stylelint"
 name = "Stylelint"
-version = "0.0.4"
+version = "1.0.0"
 schema_version = 1
 authors = ["Florian Sanders <sanders.florian+zed@gmail.com>"]
 description = "Language server extension providing diagnostics and auto-fix for Stylelint"


### PR DESCRIPTION
# Changelog

## [1.0.0](https://github.com/florian-sanders/zed-stylelint/compare/0.0.4...1.0.0) (2025-07-05)


### ✨ Features

* Get `vscode-stylelint` from `open-vsx` ([f69b19c](https://github.com/florian-sanders/zed-stylelint/f69b19c5eda5c5d31ed0a9e774295ecc98cb3d64)) - Fixes [#13](https://github.com/florian-sanders/zed-stylelint/issues/13) 
  * This removes the need for a fork of the `vscode-stylelint` extension

### 📚 Documentation

* **README:** Remove the "limitations" section ([ddf9b30](https://github.com/florian-sanders/zed-stylelint/ddf9b300308f1ae36ca3d27af5a617ca90bca12c))
  * Issues mentioned in the limitations section have been resolved so it is
no longer relevant


