### PR TITLE
chore: release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.1](https://github.com/florian-sanders/zed-stylelint/compare/1.0.0...1.0.1) (2025-07-14)
+
+
+### 🐛 Bug Fixes
+
+* **extension.toml:** Add `typescript` to supported languages ([76b0c74](https://github.com/florian-sanders/zed-stylelint/commit/76b0c74827a24691c976724c2e124e14e1304d57))
+
+
 ## [1.0.0](https://github.com/florian-sanders/zed-stylelint/compare/0.0.4...1.0.0) (2025-07-05)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "zed-stylelint"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed-stylelint"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 
 [lib]

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "stylelint"
 name = "Stylelint"
-version = "1.0.0"
+version = "1.0.1"
 schema_version = 1
 authors = ["Florian Sanders <sanders.florian+zed@gmail.com>"]
 description = "Language server extension providing diagnostics and auto-fix for Stylelint"


### PR DESCRIPTION
# Changelog

## [1.0.1](https://github.com/florian-sanders/zed-stylelint/compare/1.0.0...1.0.1) (2025-07-14)


### 🐛 Bug Fixes

* **extension.toml:** Add `typescript` to supported languages ([76b0c74](https://github.com/florian-sanders/zed-stylelint/commit/76b0c74827a24691c976724c2e124e14e1304d57))


