### PR TITLE
Fix: The parameter is incorrect. (os error 87)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ impl zed::Extension for StylelintExtension {
                     .to_string(),
                 "--stdio".to_string(),
             ],
-            env: vec![Default::default()],
+            env: Default::default(),
         })
     }
 


### PR DESCRIPTION
Fixes LSP startup error on Windows. Probably fixes #11 